### PR TITLE
Update VM download link to 4.3.8.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           <ul>
             <li><a href="https://github.com/greenplum-db/gpdb-sandbox-tutorials/zipball/master" class="button">ZIP</a></li>
             <li><a href="https://github.com/greenplum-db/gpdb-sandbox-tutorials/tarball/master" class="button">TAR</a></li>
-            <li><a href="https://network.pivotal.io/products/pivotal-gpdb#/releases/567/file_groups/337" class="button">SANDBOX VM</a></li>
+            <li><a href="https://network.pivotal.io/products/pivotal-gpdb#/releases/1683/file_groups/411" class="button">SANDBOX VM</a></li>
           </ul>
         </div>
       </div><!-- end banner -->
@@ -52,7 +52,7 @@
 <p>These tutorials showcase how Greenplum Database can address day-to-day tasks performed in typical DW, BI and data science environments. It is designed to be used with the Greenplum Database Sandbox VM that is available for download from the Pivotal Network.  Both a Virtual Box, and a VMware version are available.  The Virtual Box VM is in OVA format and can be IMPORTED into Virtual Box, while the VMware VM is a ZIP file that can be opened directly.</p>
 
 <ul>
-<li><p><a href="https://network.pivotal.io/products/pivotal-gpdb#/releases/567/file_groups/337">4.3.6.1 Greenplum Database Sandbox Virtual Machines</a></p>
+<li><p><a href="https://network.pivotal.io/products/pivotal-gpdb#/releases/1683/file_groups/411">4.3.8.1 Greenplum Database Sandbox Virtual Machines</a></p>
 
 <p>  <strong><em>Note: These VMs contain the commercially supported versions of Greenplum Database and Greenplum Command Center</em></strong></p></li>
 </ul>
@@ -1077,7 +1077,7 @@ Segment value: off
 20151201:09:08:49:172949 gpstop:gpdb-sandbox:gpadmin-[INFO]:-Gathering information and validating the environment...
 20151201:09:08:49:172949 gpstop:gpdb-sandbox:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
 20151201:09:08:49:172949 gpstop:gpdb-sandbox:gpadmin-[INFO]:-Obtaining Segment details from master...
-20151201:09:08:49:172949 gpstop:gpdb-sandbox:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 4.3.6.1 build 2'
+20151201:09:08:49:172949 gpstop:gpdb-sandbox:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 4.3.8.1'
 20151201:09:08:49:172949 gpstop:gpdb-sandbox:gpadmin-[INFO]:-Signalling all postmaster processes to reload
 .
 </code></pre></blockquote></li>


### PR DESCRIPTION
There are new versions of the sandbox VM available, update link to point to the latest and greatest version. Also update STDOUT output in example. See also https://github.com/greenplum-db/greenplum-db.github.io/pull/21 which does the corresponding change for the main website.
